### PR TITLE
EKS hyperlink fix

### DIFF
--- a/kubectl/README.md
+++ b/kubectl/README.md
@@ -1,6 +1,6 @@
 # GitHub Actions for Amazon EKS Authentication with kubectl
 
-This Action for [Amazon Elastic Container Service for Kubernetes (Amazon EKS)](https://aws.amazon.com/) that saves a [kubectl config](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) with AWS credentials and wraps the [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) command.
+This Action for [Amazon Elastic Container Service for Kubernetes (Amazon EKS)](https://aws.amazon.com/eks/) that saves a [kubectl config](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) with AWS credentials and wraps the [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) command.
 
 ## Usage
 


### PR DESCRIPTION
This should link to the EKS page, right?